### PR TITLE
**Updated:** VSIX Manifest file to allow Extension to run in Visual Studio 2019.

### DIFF
--- a/CommentTranslator/source.extension.vsixmanifest
+++ b/CommentTranslator/source.extension.vsixmanifest
@@ -10,16 +10,16 @@
     <Tags>translate, comment</Tags>
   </Metadata>
   <Installation>
-    <InstallationTarget Version="[11.0,16.0)" Id="Microsoft.VisualStudio.Community" />
-    <InstallationTarget Version="[11.0,16.0)" Id="Microsoft.VisualStudio.Pro" />
-    <InstallationTarget Version="[11.0,16.0)" Id="Microsoft.VisualStudio.Enterprise" />
+    <InstallationTarget Version="[11.0,17.0)" Id="Microsoft.VisualStudio.Community" />
+    <InstallationTarget Version="[11.0,17.0)" Id="Microsoft.VisualStudio.Pro" />
+    <InstallationTarget Version="[11.0,17.0)" Id="Microsoft.VisualStudio.Enterprise" />
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.6,)" d:InstallSource="Download" Location="https://www.microsoft.com/en-us/download/details.aspx?id=49982" />
     <Dependency Id="Microsoft.VisualStudio.MPF.15.0" DisplayName="Visual Studio MPF 15.0" d:Source="Installed" Version="[11.0,16.0)" />
   </Dependencies>
   <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[11.0,15.0]" DisplayName="Visual Studio core editor" />
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[11.0,17.0]" DisplayName="Visual Studio core editor" />
   </Prerequisites>
   <Assets>
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />


### PR DESCRIPTION
I've had a look into this one and I believe these changes should allow the Extension to work with Visual Studio 2019.

Original Issue: [Issue #13 ](https://github.com/thuantan2060/comment-translator/issues/13)

This involved some minor updates to the Manifest file to allow later Versions of Visual Studio and also updated the Version Range for the 'Microsoft.VisualStudio.Component.CoreEditor' prerequisite.

Hope this helps!